### PR TITLE
Fixed camera motion to keep player in view

### DIFF
--- a/Assets/Scripts/MouseLook.cs
+++ b/Assets/Scripts/MouseLook.cs
@@ -27,15 +27,9 @@ public class MouseLook : MonoBehaviour
         float mouseY = Input.GetAxis("Mouse Y") * mouseSensitivity * Time.deltaTime;
 
         xRotation -= mouseY; // if += rotation is opposite of desired direction
-        xRotation = Mathf.Clamp(xRotation, -90f, 90f); // prevents over rotations so the camera doesn't rotate behind the player
+        xRotation = Mathf.Clamp(xRotation, -45f, 45f); // prevents over rotations so the camera doesn't rotate behind the player
         transform.localRotation = Quaternion.Euler(xRotation, 0, 0);
 
         playerBody.Rotate(Vector3.up * mouseX);
-    }
-
-    // Makes sure the camera moves last - meaning, after the player moves
-    void LateUpdate()
-    {
-        transform.position = playerBody.transform.position + offset;
     }
 }

--- a/Assets/Scripts/MouseLook.cs
+++ b/Assets/Scripts/MouseLook.cs
@@ -11,13 +11,10 @@ public class MouseLook : MonoBehaviour
 
     public Transform playerBody;
 
-    private Vector3 offset;
-
     // Start is called before the first frame update
     void Start()
     {
         Cursor.lockState = CursorLockMode.Locked;
-        offset = transform.position - playerBody.transform.position;
     }
 
     // Update is called once per frame


### PR DESCRIPTION
Removed code that rotated the camera, now only the player rotates, and the camera along with him
clamps the rotation of the y axis to 45 degrees instead of 90